### PR TITLE
Client API Keys Guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
         text: 'Guides',
         items: [
           { text: 'Use Cases', link: '/guides/introduction' },
+          { text: 'Client API Keys', link: '/guides/client-api-keys' },
           { text: 'WMS Billing', link: '/guides/wms-billing' }
         ]
       }

--- a/docs/guides/client-api-keys.md
+++ b/docs/guides/client-api-keys.md
@@ -1,0 +1,82 @@
+---
+outline: deep
+---
+
+# Client API Keys
+
+In situations where authorized access to Trivial's API is required for a variable amount of time, you want to utilize a client API key in your requests. Client API keys are not tied to a specific user or app, and have access to all available apps.
+
+This walkthrough demonstrates how to generate and use a long-lived API key over Trivial's API. 
+
+:::warning
+This way of authenticating is only suitable in **server:server connections**, and should never be used in the UI. Exposing the token to your network provides *wide-open access* to the API.
+:::
+
+## Generating Client Keys
+
+To generate a client key, on the command line, run the following from inside of the `trivial-api` directory to get the Ruby on Rails console started: 
+```
+bundle exec rails c
+```
+:::tip
+Issues with getting the Rails console started could be troubleshooted by looking over the [repository README](https://github.com/solid-adventure/trivial-api#readme).
+:::
+
+Now, using the Rails console, store a new client key inside a `key` variable:
+```
+key = ApiKeys.issue_client_key!
+```
+
+An example response from the console might look like:
+```json
+=>
+{:key_id=>"xxx",                        
+. . .
+```
+
+You can print the entire object by simply typing `key` into the console:
+
+```json
+=>
+{:key_id=>"xxx",                        
+ :key_access_token=>"yyy"}
+```
+
+Or, you can directly copy the `key_access_token` value to your clipboard:
+```
+`echo #{key[:key_access_token]} | pbcopy`
+```
+
+:::info
+The generated `key_id` is encrypted into `key_access_token` and is only available in the result of the call. If the key is lost, it is unrecoverable.
+:::
+
+Store your `key_id` and `key_access_token` safely on your device.
+## Using Client Keys
+
+The first step in using the key is to set the `key_id` value as an environment variable in your local API. Inside of the `trivial-api/.env` file add the `CLIENT_KEYS` variable, separate multiple clients with a comma:
+```
+CLIENT_KEYS=xxx, another-key # key_id from key
+```
+With that change, your local instance now has access to the token for authorization.
+
+In your client, you can now use the access token in an API call as a Bearer token. Assuming the API is running on port 3000:
+```json
+const data = await fetch('http://localhost:3000/apps', {
+headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer yyy` // key_access_token from key
+  }
+})
+.then(response => response.json())
+
+// data: [
+//  {
+//    "id": 1,
+//    "user_id": 1,
+//    "name": "ba6811fb3e073d"...
+
+```
+
+## Example Case
+Leveraging the full capabilities of Trivial can include things like managing an event processor that chooses which app to run depending on given conditions. A client API key ensures consistent authorization to all those apps for successful event processing.

--- a/docs/guides/client-api-keys.md
+++ b/docs/guides/client-api-keys.md
@@ -4,12 +4,12 @@ outline: deep
 
 # Client API Keys
 
-In situations where authorized access to Trivial's API is required for a variable amount of time, you want to utilize a client API key in your requests. Client API keys are not tied to a specific user or app, and have access to all available apps.
+In situations where authorized access to Trivial's API is required for an indefinite amount of time, you can utilize a client API key in your requests. Client API keys are not tied to a specific user or app, and have access to all available apps.
 
 This walkthrough demonstrates how to generate and use a long-lived API key over Trivial's API. 
 
 :::warning
-This way of authenticating is only suitable in **server:server connections**, and should never be used in the UI. Exposing the token to your network provides *wide-open access* to the API.
+Client Keys only suitable in **server:server connections**, and should never be used in the UI. Exposing the token to your network would provide *wide-open access* to the API.
 :::
 
 ## Generating Client Keys
@@ -18,16 +18,13 @@ To generate a client key, on the command line, run the following from inside of 
 ```
 bundle exec rails c
 ```
-:::tip
-Issues with getting the Rails console started could be troubleshooted by looking over the [repository README](https://github.com/solid-adventure/trivial-api#readme).
-:::
 
 Now, using the Rails console, store a new client key inside a `key` variable:
 ```
 key = ApiKeys.issue_client_key!
 ```
 
-An example response from the console might look like:
+An example response from the console will look like:
 ```json
 =>
 {:key_id=>"xxx",                        
@@ -48,17 +45,17 @@ Or, you can directly copy the `key_access_token` value to your clipboard:
 ```
 
 :::info
-The generated `key_id` is encrypted into `key_access_token` and is only available in the result of the call. If the key is lost, it is unrecoverable.
+The generated `key_id` is encrypted into `key_access_token`, and they are only available in the result of the call. If the id or key is lost, it is unrecoverable.
 :::
 
 Store your `key_id` and `key_access_token` safely on your device.
 ## Using Client Keys
 
-The first step in using the key is to set the `key_id` value as an environment variable in your local API. Inside of the `trivial-api/.env` file add the `CLIENT_KEYS` variable, separate multiple clients with a comma:
+The first step in using the key is to set the `key_id` value as an environment variable. If you're running the API locally, you can add the `CLIENT_KEYS` variable to `trivial-api/.env`, separating multiple clients with a comma:
 ```
 CLIENT_KEYS=xxx, another-key # key_id from key
 ```
-With that change, your local instance now has access to the token for authorization.
+After restarting your local server, your local instance will now accept the token for authorization.
 
 In your client, you can now use the access token in an API call as a Bearer token. Assuming the API is running on port 3000:
 ```json
@@ -77,6 +74,3 @@ headers: {
 //    "name": "ba6811fb3e073d"...
 
 ```
-
-## Example Case
-Leveraging the full capabilities of Trivial can include things like managing an event processor that chooses which app to run depending on given conditions. A client API key ensures consistent authorization to all those apps for successful event processing.


### PR DESCRIPTION
In this PR a new guide is created to go alongside the newly introduced [client API keys](https://github.com/solid-adventure/trivial-api/pull/173) from the backend API. Following this guide, a user should be able to **generate** and **use** a client API token for authorization. The guide also covers general best practices as well as an example case of when this type of token would be useful. I attempted to achieve a balance of copy, code and info/warning blocks similar to that of the already existing guide.


Some things I felt needed careful attention and wording as I translated the process into a clear guide:
- Instructions to avoid exposing the `key_access_token` in the console entirely, if the user desires
- Being clear that the new environment variable is set locally
- Communicating that the environment variable has to be named `CLIENT_KEY`