### PR TITLE
Conditional Actions Guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
           { text: 'Use Cases', link: '/guides/introduction' },
           { text: 'App Tags', link: '/guides/app-tags' },
           { text: 'Client API Keys', link: '/guides/client-api-keys' },
+          { text: 'Conditional Actions', link: '/guides/conditional-actions' },
           { text: 'WMS Billing', link: '/guides/wms-billing' }
         ]
       }

--- a/docs/guides/conditional-actions.md
+++ b/docs/guides/conditional-actions.md
@@ -3,10 +3,10 @@ outline: deep
 ---
 
 # Conditional Actions Guide
-Actions can be defined with a condition, meaning they can execute depending on the success or failure of a given condition. Conditional actions allow your action to support simple filtering without needing to nest your actions inside If/Else actions. 
+Actions can define a condition, meaning they will only execute if the given condition is True. Conditional actions allow you to support simple filtering without needing to be nested in an If/Else block.
 
 ## Setting Conditions for Actions
-In order for your action to require a condition to execute, you must first modify it's `descriptor.js` file. Inside of `/actions/YOUR-SERVICE/YOUR-ACTION/descriptor.js`, return a `condition` key on `getDefinitionFields`:
+In order for your action to require a condition, you must first modify it's `descriptor.js` file. Inside of `/actions/YOUR-SERVICE/YOUR-ACTION/descriptor.js`, return a `condition` key on `getDefinitionFields`:
 
 ```javascript
   getDefinitionFields() {
@@ -27,7 +27,8 @@ Now when you add your action to your app, you will see an input for a filter.
 Conditions are evaluated as JavaScript expressions. Some examples include not executing your action unless there is a certain quantity of a single attribute:
 
 ```javascript
-// payload is automatically set to the initial request's JSON body or the output of the previous action
+// payload is automatically set to the initial request's
+// JSON body or the output of the previous action
 payload = {
   "orders" : [
     {
@@ -71,5 +72,5 @@ payload.order.customer_group.includes('VIP')
 ## `false` Conditions
 In the case that the condition you provided for an action evaluates to `false`, your action will not execute and your app will continue running. This means if you have more actions after, they will run as expected even though a condition failed for a previous action. 
 :::tip 
-`false` conditions and other app logic can be verified in your app's activity log. 
+`false` conditions and other app logic can be verified in your app's Activity Log. 
 :::

--- a/docs/guides/conditional-actions.md
+++ b/docs/guides/conditional-actions.md
@@ -1,0 +1,41 @@
+---
+outline: deep
+---
+
+# Conditional Actions Guide
+Actions can be defined with a condition, meaning they can execute depending on the success or failure of a given condition. Conditional actions transform how your app can support robust branching logic. 
+
+## Setting Conditions for Actions
+In order for your action to require a condition to execute, you must first modify it's `descriptor.js` file. Inside of `/actions/YOUR-SERVICE/YOUR-ACTION/descriptor.js`, return a `condition` key on `getDefinitionFields`:
+
+```javascript
+  getDefinitionFields() {
+    return {
+      condition: {
+        type: String,
+        required: true,
+        editorComponent: 'Condition',
+        placeholder: 'initialPayload.event_name == \'customer_signup\'',
+        example: 'initialPayload.event_name == \'customer_signup\'',
+        help: 'The condition that must be met for this action to run. If the condition is not met, the action will be skipped.'
+      }
+    }
+  }
+```
+Now when you add your action to your app, you will see an input for a filter.
+## Using Conditions
+Conditions are evaluated as JavaScript expressions. Some examples include not executing your action unless there is a certain quantity of a single attribute:
+
+```javascript
+payload.orders.length > 80
+```
+only executing on specific events:
+
+```javascript
+payload.event_name === 'customer_signup'
+```
+or only executing if specific values are included:
+
+```javascript
+payload.order.id.includes('SAMPLE_ORDER_ID')
+```

--- a/docs/guides/conditional-actions.md
+++ b/docs/guides/conditional-actions.md
@@ -3,7 +3,7 @@ outline: deep
 ---
 
 # Conditional Actions Guide
-Actions can be defined with a condition, meaning they can execute depending on the success or failure of a given condition. Conditional actions transform how your app can support robust branching logic. 
+Actions can be defined with a condition, meaning they can execute depending on the success or failure of a given condition. Conditional actions allow your action to support simple filtering without needing to nest your actions inside If/Else actions. 
 
 ## Setting Conditions for Actions
 In order for your action to require a condition to execute, you must first modify it's `descriptor.js` file. Inside of `/actions/YOUR-SERVICE/YOUR-ACTION/descriptor.js`, return a `condition` key on `getDefinitionFields`:
@@ -27,7 +27,7 @@ Now when you add your action to your app, you will see an input for a filter.
 Conditions are evaluated as JavaScript expressions. Some examples include not executing your action unless there is a certain quantity of a single attribute:
 
 ```javascript
-payload.orders.length > 80
+payload.orders.length > 100
 ```
 only executing on specific events:
 
@@ -37,5 +37,5 @@ payload.event_name === 'customer_signup'
 or only executing if specific values are included:
 
 ```javascript
-payload.order.id.includes('SAMPLE_ORDER_ID')
+payload.order.customer_group.includes('VIP')
 ```

--- a/docs/guides/conditional-actions.md
+++ b/docs/guides/conditional-actions.md
@@ -27,15 +27,49 @@ Now when you add your action to your app, you will see an input for a filter.
 Conditions are evaluated as JavaScript expressions. Some examples include not executing your action unless there is a certain quantity of a single attribute:
 
 ```javascript
+// payload is automatically set to the initial request's JSON body or the output of the previous action
+payload = {
+  "orders" : [
+    {
+      "id": 1,
+    },{
+      "id": 2,
+    },
+    ...
+  ]
+}
+```
+```javascript
 payload.orders.length > 100
 ```
 only executing on specific events:
-
+```javascript
+payload = {
+  "event_id": "HFD7GD",
+  "event_name": "customer_signup",
+  ...
+}
+```
 ```javascript
 payload.event_name === 'customer_signup'
 ```
 or only executing if specific values are included:
-
+```javascript
+payload = {
+    "order": {
+      "id": "GFS678",
+      "customer_group": [
+        "VIP"
+      ]
+    }
+}
+```
 ```javascript
 payload.order.customer_group.includes('VIP')
 ```
+
+## `false` Conditions
+In the case that the condition you provided for an action evaluates to `false`, your action will not execute and your app will continue running. This means if you have more actions after, they will run as expected even though a condition failed for a previous action. 
+:::tip 
+`false` conditions and other app logic can be verified in your app's activity log. 
+:::


### PR DESCRIPTION
This PR creates a new guide to follow the [added support](https://github.com/solid-adventure/trivial-core/pull/24) for conditional actions. Following this guide, a user should be able to add conditions to the local instances of their actions and use them to accurately execute or halt the app execution pending the condition result. The example conditions try to capture the range of capabilities offered. 

Some things I kept in mind while preparing this guide:
- The user might benefit from including screenshots of the UI in the guide, specifically what the 'When' tab looks like. I didn't add them because images aren't currently on the site and I'm not sure if we want static content, like a screenshot, that might change in the future.
- When I followed along with adding the code to my action I felt myself doing a lot of blind trusting. Users who understand what action descriptors are and how actions work might feel a bit more assured, but that part can definitely feel like magic at this point. 
- This was mentioned in the trivial-core PR, but extending the CodeCompletingEditor to always show true/false could avoid some confusion for other users. When I was testing edge cases and used conditions like `initialPayload.arr.length` it would just show the length as a number.