### PR TITLE
Updated App Tags Guide

### DIFF
--- a/docs/guides/app-tags.md
+++ b/docs/guides/app-tags.md
@@ -11,24 +11,46 @@ Adding tags to apps lets you filter responses from the Trivial API.
 
 ## Assigning Tags to Apps
 
-On the command line, run the following from inside of the `trivial-api` directory to get the Ruby on Rails console started: 
-```
-bundle exec rails c
-```
+Tags can be added or removed through the Trivial API.
 
-Now, using the Rails console, store the app instance you'd like to add a tag to in a variable. For example, storing an existing app whose `id` is `55` in a variable named `appInstance` looks like:
-```
-appInstance = App.find_by id: 55
-```
-In the console, you can now access the `addTag!` and `removeTag!` methods through your app variable.
-The following adds the `{currency: "USD"}` tag to the `appInstance` app:
-```
-appInstance.addTag!(:currency, 'USD')
-```
+You can send a `POST` request to `/apps/{appId}/tags` with a `context` and `name` in the body of the request to add a tag. Assuming the API is running on port 3000:
+```json
+const tag = await fetch('http://localhost:3000/apps/GFD67G8/tags', {
+  method: "POST",
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    "context": "currency",
+    "name": "USD"
+  })
+})
+.then(response => response.json())
+})
 
-Tags can also be removed:
+// tag: {
+//   "id": 5,
+//   "context": "currency",
+//   "name": "USD"...
+// }
 ```
-appInstance.removeTag!(:currency, 'USD')
+To remove a tag, send a `DELETE` request to the same endpoint, with the same body:
+
+```json
+await fetch('http://localhost:3000/apps/GFD67G8/tags', {
+  method: "DELETE",
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    "context": "currency",
+    "name": "USD"
+  })
+})
+.then(response => response.json())
+})
+
+// { "status": 200 }
 ```
 :::tip
 A single Trivial app can support multiple tags, but they should be added (or removed) individually and not in batches.
@@ -36,9 +58,7 @@ A single Trivial app can support multiple tags, but they should be added (or rem
 
 ## Filtering Apps with Tags
 
-By including the `tagged_with` query parameter, we can filter the response from `apps/index` to only include apps with certain tags.
-
-Assuming the API is running on port 3000:
+By including the `tagged_with` query parameter, we can filter the response from `apps/index` to only include apps with certain tags:
 ```json
 const url = new URL('apps/', 'http:localhost:3000/')
 const query = {

--- a/docs/guides/app-tags.md
+++ b/docs/guides/app-tags.md
@@ -13,8 +13,9 @@ Adding tags to apps lets you filter responses from the Trivial API.
 
 Tags can be added or removed through the Trivial API.
 
-You can send a `POST` request to `/apps/{appId}/tags` with a `context` and `name` in the body of the request to add a tag. Assuming the API is running on port 3000:
-```json
+You can send a `POST` request to `/apps/{appId}/tags` with `context` and `name` strings in the body of the request to add a tag. Assuming the API is running on port 3000:
+::: code-group
+```javascript [Request]
 const tag = await fetch('http://localhost:3000/apps/GFD67G8/tags', {
   method: "POST",
   headers: {
@@ -26,17 +27,24 @@ const tag = await fetch('http://localhost:3000/apps/GFD67G8/tags', {
   })
 })
 .then(response => response.json())
-})
-
-// tag: {
-//   "id": 5,
-//   "context": "currency",
-//   "name": "USD"...
-// }
 ```
+
+```json [Response]
+tag: {
+  "id": 1,
+  "context": "color",
+  "name": "red",
+  "taggable_type": "App",
+  "taggable_id": 1,
+  "created_at": "2023-09-28T22:16:19.297Z",
+  "updated_at": "2023-09-28T22:16:19.297Z"
+}
+```
+:::
 To remove a tag, send a `DELETE` request to the same endpoint, with the same body:
 
-```json
+::: code-group 
+```javascript [Request]
 await fetch('http://localhost:3000/apps/GFD67G8/tags', {
   method: "DELETE",
   headers: {
@@ -48,18 +56,22 @@ await fetch('http://localhost:3000/apps/GFD67G8/tags', {
   })
 })
 .then(response => response.json())
-})
-
-// { "status": 200 }
 ```
+```json [Response]
+{ "status": 200 }
+```
+:::
+
 :::tip
 A single Trivial app can support multiple tags, but they should be added (or removed) individually and not in batches.
 :::
 
 ## Filtering Apps with Tags
 
-By including the `tagged_with` query parameter, we can filter the response from `apps/index` to only include apps with certain tags:
-```json
+By including the `tagged_with` query parameter, we can filter the response from `apps/` to only include apps with certain tags:
+
+::: code-group
+```javascript [Request]
 const url = new URL('apps/', 'http:localhost:3000/')
 const query = {
       tagged_with: JSON.stringify([
@@ -70,16 +82,145 @@ const query = {
 const search = new URLSearchParams(query)
 url.search = search.toString()
 
-url.href
-// 'http://localhost:3000/apps/?tagged_with=%5B%7B%22currency%22%3A%22USD%22%7D%2C%7B%22colors%22%3A%22red%22%7D%5D'
+// url.href == 'http://localhost:3000/apps/?tagged_with=%5B%7B%22currency%22%3A%22USD%22%7D%2C%7B%22colors%22%3A%22red%22%7D%5D'
+
+const taggedApps = await fetch(url.href,{
+  headers: { 'Content-Type': 'application/json' }
+})
+.then(response => response.json())
+
 ```
 
-This call will return an array of apps with matching tags like so: 
-```json
-data: [
-  {
-    "id": 55,
-    "name": "ba6811fb3e073d",
-    "descriptive_name": "All apps matching all tags provided",
-    "hostname": "ba6811fb3e073d"...
+```json [Response]
+taggedApps: [
+    {
+        "id": 1,
+        "name": "cxg564s7dg",
+        "descriptive_name": "App one",
+        "hostname": "cxg564s7dg",
+        "domain": "staging.trivialapps.io",
+        "load_balancer": "staging-lb",
+        "panels": null,
+        "readable_by": null,
+        "schedule": null,
+        "aws_role": "arn:aws:iam::1234:role/AAlambda-ex-1",
+        "created_at": "2023-09-28T00:00:00.292Z",
+        "updated_at": "2023-09-28T00:00:00.292Z",
+        "manifest": {},
+        "tags": [
+            {
+                "id": 1,
+                "context": "colors",
+                "name": "red",
+                "taggable_type": "App",
+                "taggable_id": 1,
+                "created_at": "2023-09-28T00:00:10.297Z",
+                "updated_at": "2023-09-28T00:00:10.297Z"
+            },
+            {
+                "id": 2,
+                "context": "currency",
+                "name": "USD",
+                "taggable_type": "App",
+                "taggable_id": 1,
+                "created_at": "2023-09-28T00:00:29.297Z",
+                "updated_at": "2023-09-28T00:00:29.297Z"
+            },
+        ]
+    },
+    {
+        "id": 2,
+        "name": "dgs6g7s8fgf",
+        "descriptive_name": "App two",
+        "hostname": "dgs6g7s8fgf",
+        "domain": "staging.trivialapps.io",
+        "load_balancer": "staging-lb",
+        "panels": null,
+        "readable_by": null,
+        "schedule": null,
+        "aws_role": "arn:aws:iam::1234:role/AAlambda-ex-1",
+        "created_at": "2023-09-28T00:10:00.292Z",
+        "updated_at": "2023-09-28T00:10:00.292Z",
+        "manifest": {},
+        "tags": [
+            {
+                "id": 1,
+                "context": "colors",
+                "name": "red",
+                "taggable_type": "App",
+                "taggable_id": 1,
+                "created_at": "2023-09-28T00:10:10.297Z",
+                "updated_at": "2023-09-28T00:10:10.297Z"
+            },
+            {
+                "id": 2,
+                "context": "currency",
+                "name": "USD",
+                "taggable_type": "App",
+                "taggable_id": 1,
+                "created_at": "2023-09-28T00:10:29.297Z",
+                "updated_at": "2023-09-28T00:10:29.297Z"
+            },
+        ]
+    },
+    {
+        "id": 3,
+        "name": "dfds789sej",
+        "descriptive_name": "App three",
+        "hostname": "dfds789sej",
+        "domain": "staging.trivialapps.io",
+        "load_balancer": "staging-lb",
+        "panels": null,
+        "readable_by": null,
+        "schedule": null,
+        "aws_role": "arn:aws:iam::1234:role/AAlambda-ex-1",
+        "created_at": "2023-09-28T00:20:00.292Z",
+        "updated_at": "2023-09-28T00:20:00.292Z",
+        "manifest": {},
+        "tags": [
+            {
+                "id": 1,
+                "context": "colors",
+                "name": "red",
+                "taggable_type": "App",
+                "taggable_id": 1,
+                "created_at": "2023-09-28T00:20:10.297Z",
+                "updated_at": "2023-09-28T00:20:10.297Z"
+            },
+            {
+                "id": 2,
+                "context": "currency",
+                "name": "USD",
+                "taggable_type": "App",
+                "taggable_id": 1,
+                "created_at": "2023-09-28T00:20:29.297Z",
+                "updated_at": "2023-09-28T00:20:29.297Z"
+            },
+        ]
+    },
+]
 ```
+:::
+
+Filtering with tags that do not exist yields empty results:
+::: code-group
+```javascript [Request]
+const url = new URL('apps/', 'http:localhost:3000/')
+const query = {
+      tagged_with: JSON.stringify([
+        {currency: "CAD"},
+      ])
+    }
+const search = new URLSearchParams(query)
+url.search = search.toString()
+
+const taggedApps = await fetch(url.href,{
+  headers: { 'Content-Type': 'application/json' }
+})
+.then(response => response.json())
+
+```
+``` json [Response]
+taggedApps: []
+```
+:::

--- a/docs/guides/app-tags.md
+++ b/docs/guides/app-tags.md
@@ -16,7 +16,7 @@ Tags can be added or removed through the Trivial API.
 You can send a `POST` request to `/apps/{appId}/tags` with `context` and `name` strings in the body of the request to add a tag. Assuming the API is running on port 3000:
 ::: code-group
 ```javascript [Request]
-const tag = await fetch('http://localhost:3000/apps/GFD67G8/tags', {
+const tag = await fetch('http://localhost:3000/apps/{appId}/tags', {
   method: "POST",
   headers: {
     'Content-Type': 'application/json',
@@ -45,7 +45,7 @@ To remove a tag, send a `DELETE` request to the same endpoint, with the same bod
 
 ::: code-group 
 ```javascript [Request]
-await fetch('http://localhost:3000/apps/GFD67G8/tags', {
+await fetch('http://localhost:3000/apps/{appId}/tags', {
   method: "DELETE",
   headers: {
     'Content-Type': 'application/json',
@@ -95,9 +95,9 @@ const taggedApps = await fetch(url.href,{
 taggedApps: [
     {
         "id": 1,
-        "name": "cxg564s7dg",
+        "name": "XXXXX",
         "descriptive_name": "App one",
-        "hostname": "cxg564s7dg",
+        "hostname": "XXXXX",
         "domain": "staging.trivialapps.io",
         "load_balancer": "staging-lb",
         "panels": null,
@@ -130,9 +130,9 @@ taggedApps: [
     },
     {
         "id": 2,
-        "name": "dgs6g7s8fgf",
+        "name": "YYYYY",
         "descriptive_name": "App two",
-        "hostname": "dgs6g7s8fgf",
+        "hostname": "YYYYY",
         "domain": "staging.trivialapps.io",
         "load_balancer": "staging-lb",
         "panels": null,
@@ -144,7 +144,7 @@ taggedApps: [
         "manifest": {},
         "tags": [
             {
-                "id": 1,
+                "id": 3,
                 "context": "colors",
                 "name": "red",
                 "taggable_type": "App",
@@ -153,7 +153,7 @@ taggedApps: [
                 "updated_at": "2023-09-28T00:10:10.297Z"
             },
             {
-                "id": 2,
+                "id": 4,
                 "context": "currency",
                 "name": "USD",
                 "taggable_type": "App",
@@ -165,9 +165,9 @@ taggedApps: [
     },
     {
         "id": 3,
-        "name": "dfds789sej",
+        "name": "ZZZZZ",
         "descriptive_name": "App three",
-        "hostname": "dfds789sej",
+        "hostname": "ZZZZZ",
         "domain": "staging.trivialapps.io",
         "load_balancer": "staging-lb",
         "panels": null,
@@ -179,7 +179,7 @@ taggedApps: [
         "manifest": {},
         "tags": [
             {
-                "id": 1,
+                "id": 5,
                 "context": "colors",
                 "name": "red",
                 "taggable_type": "App",
@@ -188,7 +188,7 @@ taggedApps: [
                 "updated_at": "2023-09-28T00:20:10.297Z"
             },
             {
-                "id": 2,
+                "id": 6,
                 "context": "currency",
                 "name": "USD",
                 "taggable_type": "App",


### PR DESCRIPTION
**Before**
The existing guide for App Tags instructed users on how to create and delete app tags through the rails console.

**After**
The App Tags guide has been updated to reflect the [changes to the API](https://github.com/solid-adventure/trivial-api/pull/178) for tag support. Now following this guide, users will be able to manage tags through the API instead of a local rails console. 

The guide goes over example API calls as well as example responses from the API.