### PR TITLE
Organizations Guide

### DIFF
--- a/docs/.vitepress/cache/deps/_metadata.json
+++ b/docs/.vitepress/cache/deps/_metadata.json
@@ -1,11 +1,11 @@
 {
-  "hash": "e881e2b8",
-  "browserHash": "27cb0002",
+  "hash": "dd555fae",
+  "browserHash": "d72b2163",
   "optimized": {
     "vue": {
       "src": "../../../../node_modules/vue/dist/vue.runtime.esm-bundler.js",
       "file": "vue.js",
-      "fileHash": "e51a1fbf",
+      "fileHash": "8bf5b1ce",
       "needsInterop": false
     }
   },

--- a/docs/.vitepress/cache/deps/_metadata.json
+++ b/docs/.vitepress/cache/deps/_metadata.json
@@ -1,11 +1,11 @@
 {
-  "hash": "dd555fae",
-  "browserHash": "d72b2163",
+  "hash": "e881e2b8",
+  "browserHash": "27cb0002",
   "optimized": {
     "vue": {
       "src": "../../../../node_modules/vue/dist/vue.runtime.esm-bundler.js",
       "file": "vue.js",
-      "fileHash": "8bf5b1ce",
+      "fileHash": "e51a1fbf",
       "needsInterop": false
     }
   },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -31,7 +31,9 @@ export default defineConfig({
         items: [
           { text: 'App Tags', link: '/guides/app-tags' },
           { text: 'Client API Keys', link: '/guides/client-api-keys' },
-          { text: 'Conditional Actions', link: '/guides/conditional-actions' }
+          { text: 'Conditional Actions', link: '/guides/conditional-actions' },
+          { text: 'Organizations', link: '/guides/organizations' }
+          
         ]
       }
     ],

--- a/docs/guides/organizations.md
+++ b/docs/guides/organizations.md
@@ -100,7 +100,7 @@ Attributes about the Organization and its users can also be managed through the 
 ::: code-group
 ```javascript [Request]
 const updatedOrganization = await fetch('http://localhost:3000/organization/{organizationId}', {
-  method: "PATCH",
+  method: "PUT",
   headers: {
     'Content-Type': 'application/json',
   },

--- a/docs/guides/organizations.md
+++ b/docs/guides/organizations.md
@@ -4,14 +4,14 @@ outline: deep
 
 # Organizations
 
-Organizations on Trivial allow you to collaborate with others by enabling powerful and customizable Role-based access control to Apps. When you create an Organization in Trivial, you control the set of users and their level of access to Apps owned by your Organization.
+Trivial Organizations allow you to collaborate with other users by enabling powerful and customizable Role-based access control to Apps. When you create an Organization in Trivial, you control the set of users and their level of access to Apps owned by your Organization.
 
 
 ## Create an Organization
  
 Organizations can be created through the Trivial API.
 
-Send a `POST` request to `/organizations` with `name` and `billing_email` strings in the body of the request to create your first organization. Assuming the API is running on port 3000:
+Send a `POST` request to `/organizations` with `name` and `billing_email` strings in the body of the request to create your first Organization. Assuming the API is running on port 3000:
 ::: code-group
 ```javascript [Request]
 const organization = await fetch('http://localhost:3000/organizations', {
@@ -34,10 +34,10 @@ organization: {
 }
 ```
 :::
-By default you are registered as an `admin` user of an organization you create. 
+By default you are registered as an `admin` user of an Organization you create. 
 
 ## Viewing your Organizations
-Organizations you are a part of can be viewed in two ways- your individual organizations can be fetched by their ID's:
+Organizations you are a part of can be viewed in two ways- your individual Organizations can be fetched by their ID's:
 ::: code-group
 ```javascript [Request]
 const organization = await fetch('http://localhost:3000/organizations/{organizationId}', {
@@ -64,7 +64,7 @@ organization: {
 ```
 :::
 
-Or you can fetch all your organizations:
+Or you can fetch all your Organizations:
 ::: code-group
 ```javascript [Request]
 const organizations = await fetch('http://localhost:3000/organizations', {
@@ -90,13 +90,13 @@ organizations: [
 ```
 :::
 :::info
-You only see an organization's list of users when you fetch the individual organization.
+You only see an Organization's list of users when you fetch the individual Organization.
 :::
 
 ## Organization Management
-Attributes about the organization and its users can also be managed through the Trivial API.
+Attributes about the Organization and its users can also be managed through the Trivial API. Only `admin` users are authorized to make these changes.
 
-Updates to an organization are handled with a `PATCH` request:
+### Updating Organizations
 ::: code-group
 ```javascript [Request]
 const updatedOrganization = await fetch('http://localhost:3000/organization/{organizationId}', {
@@ -119,7 +119,7 @@ updatedOrganization: {
 ```
 :::
 
-Organizations can also be deleted:
+### Deleting Organizations
 ::: code-group
 ```javascript [Request]
 await fetch('http://localhost:3000/organization/{organizationId}', {
@@ -131,18 +131,17 @@ await fetch('http://localhost:3000/organization/{organizationId}', {
 .then(response => response.json())
 ```
 ```json [Response]
-{ status: 200 }
+{ message: 'Delete OK' }
 ```
 :::
 
-## Membership Management
-Finally, user membership of Organizations is handled with it's own set of API requests.
+Finally, `admin` users can also manage users of Organizations.
 
-Adding users:
+### Adding users
 ::: code-group
 ```javascript [Request]
 // adding a user as a member
-const newMember = await fetch('http://localhost:3000/organizations/{organizationId}/create_org_role}', {
+const newUser = await fetch('http://localhost:3000/organizations/{organizationId}/create_org_role}', {
   method: "POST",
   headers: {
     'Content-Type': 'application/json',
@@ -155,7 +154,7 @@ const newMember = await fetch('http://localhost:3000/organizations/{organization
 .then(response => response.json())
 ```
 ```json [Response]
-newMember: {
+newUser: {
     "id": 1,
     "name": "My Organization",
     "billing_email": "organization@email.com",
@@ -177,11 +176,11 @@ newMember: {
 ```
 :::
 
-Updating members:
+### Updating users
 ::: code-group
 ```javascript [Request]
 // updating a user to admin role
-const updatedMember = await fetch('http://localhost:3000/organizations/{organizationId}/update_org_role}', {
+const updatedUser = await fetch('http://localhost:3000/organizations/{organizationId}/update_org_role}', {
   method: "PUT",
   headers: {
     'Content-Type': 'application/json',
@@ -194,7 +193,7 @@ const updatedMember = await fetch('http://localhost:3000/organizations/{organiza
 .then(response => response.json())
 ```
 ```json [Response]
-newMember: {
+updatedUser: {
     "id": 1,
     "name": "My Organization",
     "billing_email": "organization@email.com",
@@ -216,7 +215,7 @@ newMember: {
 ```
 :::
 
-Deleting members/leaving organizations:
+### Deleting users/leaving Organizations
 ::: code-group
 ```javascript [Request]
 await fetch('http://localhost:3000/organizations/{organizationId}/delete_org_role}', {
@@ -231,6 +230,6 @@ await fetch('http://localhost:3000/organizations/{organizationId}/delete_org_rol
 .then(response => response.json())
 ```
 ```json [Response]
-{ status: 200 }
+{ message: 'Delete OK' }
 ```
 :::

--- a/docs/guides/organizations.md
+++ b/docs/guides/organizations.md
@@ -1,0 +1,236 @@
+---
+outline: deep
+---
+
+# Organizations
+
+Organizations on Trivial allow you to collaborate with others by enabling powerful and customizable Role-based access control to Apps. When you create an Organization in Trivial, you control the set of users and their level of access to Apps owned by your Organization.
+
+
+## Create an Organization
+ 
+Organizations can be created through the Trivial API.
+
+Send a `POST` request to `/organizations` with `name` and `billing_email` strings in the body of the request to create your first organization. Assuming the API is running on port 3000:
+::: code-group
+```javascript [Request]
+const organization = await fetch('http://localhost:3000/organizations', {
+  method: "POST",
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    "name": "My Organization",
+    "billing_email": "organization@email.com"
+  })
+})
+.then(response => response.json())
+```
+```json [Response]
+organization: {
+    "id": 1,
+    "name": "My Organization",
+    "billing_email": "organization@email.com"
+}
+```
+:::
+By default you are registered as an `admin` user of an organization you create. 
+
+## Viewing your Organizations
+Organizations you are a part of can be viewed in two ways- your individual organizations can be fetched by their ID's:
+::: code-group
+```javascript [Request]
+const organization = await fetch('http://localhost:3000/organizations/{organizationId}', {
+  headers: {
+    'Content-Type': 'application/json',
+  }
+})
+.then(response => response.json())
+```
+```json [Response]
+organization: {
+    "id": 1,
+    "name": "My Organization",
+    "billing_email": "organization@email.com",
+    "users": [
+      {
+        "user_id": 1,
+        "name": "admin",
+        "email": "admin@email.com",
+        "role": "admin"
+      }
+    ]
+}
+```
+:::
+
+Or you can fetch all your organizations:
+::: code-group
+```javascript [Request]
+const organizations = await fetch('http://localhost:3000/organizations', {
+  headers: {
+    'Content-Type': 'application/json',
+  }
+})
+.then(response => response.json())
+```
+```json [Response]
+organizations: [
+  {
+    "id": 1,
+    "name": "My Organization",
+    "billing_email": "organization@email.com"
+  },
+  {
+    "id": 2,
+    "name": "My Second Organization",
+    "billing_email": "organizationTwo@email.com"
+  }
+]
+```
+:::
+:::info
+You only see an organization's list of users when you fetch the individual organization.
+:::
+
+## Organization Management
+Attributes about the organization and its users can also be managed through the Trivial API.
+
+Updates to an organization are handled with a `PATCH` request:
+::: code-group
+```javascript [Request]
+const updatedOrganization = await fetch('http://localhost:3000/organization/{organizationId}', {
+  method: "PATCH",
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    "name": "New Organization Name"
+  })
+})
+.then(response => response.json())
+```
+```json [Response]
+updatedOrganization: {
+    "id": 1,
+    "name": "New Organization Name",
+    "billing_email": "organization@email.com"
+}
+```
+:::
+
+Organizations can also be deleted:
+::: code-group
+```javascript [Request]
+await fetch('http://localhost:3000/organization/{organizationId}', {
+  method: "DELETE",
+  headers: {
+    'Content-Type': 'application/json',
+  }
+})
+.then(response => response.json())
+```
+```json [Response]
+{ status: 200 }
+```
+:::
+
+## Membership Management
+Finally, user membership of Organizations is handled with it's own set of API requests.
+
+Adding users:
+::: code-group
+```javascript [Request]
+// adding a user as a member
+const newMember = await fetch('http://localhost:3000/organizations/{organizationId}/create_org_role}', {
+  method: "POST",
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    "user_id": 2,
+    "role": "member"
+  })
+})
+.then(response => response.json())
+```
+```json [Response]
+newMember: {
+    "id": 1,
+    "name": "My Organization",
+    "billing_email": "organization@email.com",
+    "users": [
+      {
+        "user_id": 1,
+        "name": "admin",
+        "email": "admin@email.com",
+        "role": "admin"
+      },
+      {
+        "user_id": 2,
+        "name": "user2",
+        "email": "user2@email.com",
+        "role": "member"
+      }
+    ]
+}
+```
+:::
+
+Updating members:
+::: code-group
+```javascript [Request]
+// updating a user to admin role
+const updatedMember = await fetch('http://localhost:3000/organizations/{organizationId}/update_org_role}', {
+  method: "PUT",
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    "user_id": 2,
+    "role": "admin"
+  })
+})
+.then(response => response.json())
+```
+```json [Response]
+newMember: {
+    "id": 1,
+    "name": "My Organization",
+    "billing_email": "organization@email.com",
+    "users": [
+      {
+        "user_id": 1,
+        "name": "admin",
+        "email": "admin@email.com",
+        "role": "admin"
+      },
+      {
+        "user_id": 2,
+        "name": "user2",
+        "email": "user2@email.com",
+        "role": "admin"
+      }
+    ]
+}
+```
+:::
+
+Deleting members/leaving organizations:
+::: code-group
+```javascript [Request]
+await fetch('http://localhost:3000/organizations/{organizationId}/delete_org_role}', {
+  method: "DELETE",
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    "user_id": 2
+  })
+})
+.then(response => response.json())
+```
+```json [Response]
+{ status: 200 }
+```
+:::


### PR DESCRIPTION
In this PR a new guide is created to follow the newly introduced [Organizations API resource](https://github.com/solid-adventure/trivial-api/pull/180). Following this guide, a user should be able to create an organization as well as handle all of its management through the API.

Some things that I kept in mind when writing the guide: 
- This guide covers more API requests than any other so there was extra effort to keep the copy as direct as possible. The Organization Management section of the guide feels concise but also redundant because it is just request after request.
- Mentioning that the users of an organization can only be seen with the `/organizations/id` endpoint (included in an 'info' tab in the guide).