### PR TITLE
Permissions Guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -32,7 +32,8 @@ export default defineConfig({
           { text: 'App Tags', link: '/guides/app-tags' },
           { text: 'Client API Keys', link: '/guides/client-api-keys' },
           { text: 'Conditional Actions', link: '/guides/conditional-actions' },
-          { text: 'Organizations', link: '/guides/organizations' }
+          { text: 'Organizations', link: '/guides/organizations' },
+          { text: 'Permissions', link: '/guides/permissions' }
           
         ]
       }

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -1,0 +1,61 @@
+---
+outline: deep
+---
+
+# Permissions
+
+Trivial Permissions make it possible to share resources by granting Users with access to perform different operations on various resources. Permissions currently make it possible to share the `App`, `Manifest`, `ManifestDraft`, and `CredentialSet` resources. For every one of those resources there exists grantable permissions for the following operations: `read`, `update`, `delete`, `transfer`, `grant`, and `revoke`.
+
+## The Permissions API
+
+Permissions can be granted through the Trivial API. 
+
+The `/permission` endpoint is for interacting with singular permits. 
+
+A request to the Permissions API follows the schema:
+``` /permission/{permit}/{permissible_type}/{permissible_id}/users/{user_id} ```
+- `{permit}` is the name of the operation.
+- `{permissible_type}` is the name of the resource.
+- `{permissible_id}` is the internal ID for that resource instance.
+- `{user_id}` is the internal user ID for the user being granted the permission.
+
+The `/permissions` endpoint also exists to handle multiple permits at once. A request to this endpoint will omit the `permit`:
+```/permissions/{permissible_type}/{permissible_id}/users/{user_id}```
+
+## Granting Users Permissions to Resources
+
+As an example, send a `POST` request to `/permissions/credential_sets/1/users/5` to grant *all* permissions to user 5 for credential set 1. Assuming the API is running on port 3000:
+:::code-group
+```javascript [Request]
+await fetch('http://localhost:3000/permissions/credential_sets/1/users/5', {
+  method: "POST",
+  headers: { 'Content-Type': 'application/json' }
+})
+.then(response => response.json())
+```
+```json [Response]
+200: ok
+```
+::: 
+
+## Revoking Permissions 
+
+To revoke a user's Permission from a resource, a `DELETE` request can be sent to the desired endpoint:
+:::code-group
+```javascript [Request]
+// revoke only the transfer permit from user 1 on manifest 1
+await fetch('http://localhost:3000/permission/transfer/manifests/1/users/1', {
+  method: "DELETE",
+  headers: { 'Content-Type': 'application/json' }
+})
+.then(response => response.json())
+```
+```json [Response]
+200: ok
+```
+:::
+
+:::info
+Revoking is not the same as deleting. When a user has all their permissions revoked there is an entry left in the database for historical record puroposes.
+:::
+

--- a/docs/guides/permissions.md
+++ b/docs/guides/permissions.md
@@ -19,7 +19,7 @@ A request to the Permissions API follows the schema:
 - `{permissible_id}` is the internal ID for that resource instance.
 - `{user_id}` is the internal user ID for the user being granted the permission.
 
-The `/permissions` endpoint also exists to handle multiple permits at once. A request to this endpoint will omit the `permit`:
+The `/permissions` endpoint is for interacting with multiple permits. A request to this endpoint will omit the `permit`:
 ```/permissions/{permissible_type}/{permissible_id}/users/{user_id}```
 
 ## Granting Users Permissions to Resources
@@ -34,7 +34,31 @@ await fetch('http://localhost:3000/permissions/credential_sets/1/users/5', {
 .then(response => response.json())
 ```
 ```json [Response]
-200: ok
+{
+    "user_id": 5,
+    "permissions": [
+        {
+            "permissible_type": "Credential Set",
+            "permissible_id": 1,
+            "permits": [
+                "read",
+                "update",
+                "destroy",
+                "transfer",
+                "grant",
+                "revoke"
+            ],
+            "ids": [
+                21,
+                22,
+                23,
+                24,
+                25,
+                26
+            ]
+        }
+    ]
+}
 ```
 ::: 
 
@@ -51,7 +75,7 @@ await fetch('http://localhost:3000/permission/transfer/manifests/1/users/1', {
 .then(response => response.json())
 ```
 ```json [Response]
-200: ok
+{ message: 'Delete OK' }
 ```
 :::
 


### PR DESCRIPTION
In this PR a new guide is created to go alongside the newly introduced [Permissions](https://github.com/solid-adventure/trivial-api/pull/184) API Model that enables resource sharing. Following the guide, a user should be able to understand the Permissions API endpoint schema as well as generate and revoke permissions for other users.

Some things that I felt were important when writing the guide:
- Being clear that revoking a permission is not the same as deleting, especially because revoking is done through a DELETE request
- Having a dedicated space at the start of the guide to brief on the Permissions API endpoint schema. In previous guides the API endpoints were fairly intuitive, so this dedicated segment of backend documentation felt like it distinguished this guide. Wondering if this guide is the right place to go into such fine detail about the API.