### PR TITLE
Testing guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
           { text: 'Conditional Actions', link: '/guides/conditional-actions' },
           { text: 'Organizations', link: '/guides/organizations' },
           { text: 'Permissions', link: '/guides/permissions' },
-          { text: 'Testing', link:'/guides/testing'}
+          { text: 'Staging', link:'/guides/staging'}
           
         ]
       }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -46,5 +46,6 @@ export default defineConfig({
     // socialLinks: [
     //   { icon: 'github', link: 'https://github.com/vuejs/vitepress' }
     // ]
-  }
+  }, 
+  ignoreDeadLinks: true
 })

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -33,7 +33,8 @@ export default defineConfig({
           { text: 'Client API Keys', link: '/guides/client-api-keys' },
           { text: 'Conditional Actions', link: '/guides/conditional-actions' },
           { text: 'Organizations', link: '/guides/organizations' },
-          { text: 'Permissions', link: '/guides/permissions' }
+          { text: 'Permissions', link: '/guides/permissions' },
+          { text: 'Testing', link:'/guides/testing'}
           
         ]
       }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
           { text: 'Conditional Actions', link: '/guides/conditional-actions' },
           { text: 'Organizations', link: '/guides/organizations' },
           { text: 'Permissions', link: '/guides/permissions' },
-          { text: 'Staging', link:'/guides/staging'}
+          { text: 'Hosted Staging Env', link:'/guides/staging'}
           
         ]
       }

--- a/docs/guides/staging.md
+++ b/docs/guides/staging.md
@@ -2,9 +2,9 @@
 outline: deep
 ---
 
-# Testing
+# Staging
 
-The easiest way to test your trivial-ui install is working correctly is to use the hosted staging API server.
+The easiest way to test that your trivial-ui install is working correctly is to use the hosted staging API server.
 
 ## Accessing Staging API Server
 

--- a/docs/guides/staging.md
+++ b/docs/guides/staging.md
@@ -19,4 +19,5 @@ TRIVIAL_URL = https://trivial-api-staging.herokuapp.com
 ```
 Once the env variable is added, restart your local trivial-ui. For more about the env file, please refer to the trivial-ui [repository](https://github.com/solid-adventure/trivial-ui).
 
-3. Login to your local trivial-ui using the credentials created on step 1 at  <a href="http://localhost:3000/login" target="_blank" rel="noreferrer">http://localhost:3000/login</a>.
+3. Login to your local trivial-ui using the credentials created on step 1 at 
+<a href="http://localhost:3000/login" target="_blank" rel="noreferrer">http://localhost:3000/login</a>

--- a/docs/guides/staging.md
+++ b/docs/guides/staging.md
@@ -19,4 +19,4 @@ TRIVIAL_URL = https://trivial-api-staging.herokuapp.com
 ```
 Once the env variable is added, restart your local trivial-ui. For more about the env file, please refer to the trivial-ui [repository](https://github.com/solid-adventure/trivial-ui).
 
-3. Login to your local trivial-ui using the credentials created on step 1 at [http://localhost:3000/login](http://localhost:3000/login).
+3. Login to your local trivial-ui using the credentials created on step 1 at  <a href="http://localhost:3000/login" target="_blank" rel="noreferrer">http://localhost:3000/login</a>.

--- a/docs/guides/staging.md
+++ b/docs/guides/staging.md
@@ -20,4 +20,4 @@ TRIVIAL_URL = https://trivial-api-staging.herokuapp.com
 Once the env variable is added, restart your local trivial-ui. For more about the env file, please refer to the trivial-ui [repository](https://github.com/solid-adventure/trivial-ui).
 
 3. Login to your local trivial-ui using the credentials created on step 1 at 
-<a href="http://localhost:3000/login" target="_blank" rel="noreferrer">http://localhost:3000/login</a>
+[http://localhost:3000/login](http://localhost:3000/login).

--- a/docs/guides/staging.md
+++ b/docs/guides/staging.md
@@ -19,4 +19,4 @@ TRIVIAL_URL = https://trivial-api-staging.herokuapp.com
 ```
 Once the env variable is added, restart your local trivial-ui. For more about the env file, please refer to the trivial-ui [repository](https://github.com/solid-adventure/trivial-ui).
 
-3. Login to your local trivial-ui using the credentials created on step 1 at http://localhost:3000/login
+3. Login to your local trivial-ui using the credentials created on step 1 at [http://localhost:3000/login](http://localhost:3000/login).

--- a/docs/guides/staging.md
+++ b/docs/guides/staging.md
@@ -19,4 +19,4 @@ TRIVIAL_URL = https://trivial-api-staging.herokuapp.com
 ```
 Once the env variable is added, restart your local trivial-ui. For more about the env file, please refer to the trivial-ui [repository](https://github.com/solid-adventure/trivial-ui).
 
-3. Login to your local trivial-ui using the credentials created on step 1.
+3. Login to your local trivial-ui using the credentials created on step 1 at http://localhost:3000/login

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -10,13 +10,13 @@ The easiest way to test your trivial-ui install is working correctly is to use t
 
 To host your trivial-ui on staging enviorment do the following:
 
-1. Create an account via the registration [site](https://www.staging.trivialapps.io/register).
+1. Create an account via the staging environment registration [site](https://www.staging.trivialapps.io/register).
 
-2. In you env file, add or set the following: 
+2. In you env file, add or uncomment the following: 
 :::code-group
 ```YAML [.env]
-TRIVIAL_URL = https://trivial-api-staging.herokuapp.com. 
+TRIVIAL_URL = https://trivial-api-staging.herokuapp.com
 ```
-For more specifics, please refer to the trivial-ui [repository](https://github.com/solid-adventure/trivial-ui).
+Once the env variable is added, restart your local trivial-ui. For more about the env file, please refer to the trivial-ui [repository](https://github.com/solid-adventure/trivial-ui).
 
-3. 
+3. Login to your local trivial-ui using the credentials created on step 1.

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,0 +1,22 @@
+---
+outline: deep
+---
+
+# Testing
+
+The easiest way to test your trivial-ui install is working correctly is to use the hosted staging API server.
+
+## Accessing Staging API Server
+
+To host your trivial-ui on staging enviorment do the following:
+
+1. Create an account via the registration [site](https://www.staging.trivialapps.io/register).
+
+2. In you env file, add or set the following: 
+:::code-group
+```YAML [.env]
+TRIVIAL_URL = https://trivial-api-staging.herokuapp.com. 
+```
+For more specifics, please refer to the trivial-ui [repository](https://github.com/solid-adventure/trivial-ui).
+
+3. 


### PR DESCRIPTION
This PR addes a guide that show users how to access and use staging API server to correctly check if their local-trivial ui is working.
Questions:
- James mentioned to add a link to getting started page. Where could this be added to our page? Would this be somewhere along the lines of "Please refer to the getting started in order to create a local trivial-ui prior to access staging API server."?
- I would also like some feedback on the name of the guide is "Staging" appropriate? I had been previously named it "Testing", but felt that it wasn't the core topic of the guide.
